### PR TITLE
TeX::Interpreter::latex: use graphic elements in math-mode

### DIFF
--- a/lib/perl/TeX/Interpreter/FMT/latex.pm
+++ b/lib/perl/TeX/Interpreter/FMT/latex.pm
@@ -868,16 +868,10 @@ __DATA__
 %% Note that the optional argument is currently ignored.
 
 \newcommand{\TeXMLImportGraphic}[2][]{%
-    \ifmmode
-        \string\vcenter\string{%
-            \string\img\string{#2\string}%
-        \string}%
-    \else
         \startXMLelement{\jats@graphics@element}%
         \setXMLattribute{xlink:href}{#2}%
         \TeXML@add@graphic@attributes{#2}%
         \endXMLelement{\jats@graphics@element}%
-    \fi
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2227,11 +2221,6 @@ __DATA__
 
 \def\hspace{\ifmmode\expandafter\math@hspace\else\expandafter\txt@hspace\fi}
 
-\edef\MathJaxImg[#1]#2{%
-    \string\vcenter\string{%
-        \string\img[#1]\string{#2\string}%
-    \string}%
-}
 
 \def\DeclareMathJaxMacro{%
   \@ifstar{\@DeclareMathJaxMacro{}}{\@DeclareMathJaxMacro{ }}%

--- a/lib/perl/TeX/Interpreter/LaTeX.pm
+++ b/lib/perl/TeX/Interpreter/LaTeX.pm
@@ -777,30 +777,11 @@ sub do_texml_create_svg {
 
     return unless nonempty($out_file) && -e $out_file;
 
-    if ($is_mmode) {
         if (nonempty($opt)) {
             $expansion = qq{\\TeXMLImportGraphic[$opt]{$out_file}};
         } else {
             $expansion = qq{\\TeXMLImportGraphic{$out_file}};
         }
-    } else {
-        my $doc = XML::LibXML->load_xml(location => $out_file);
-
-        my $root = $doc->documentElement();
-
-        my $width  = $root->getAttribute("width");
-        my $height = $root->getAttribute("height");
-
-        my $size = qq{width=$width,height=$height};
-
-        if (empty($opt)) {
-            $opt = $size;
-        } else {
-            $opt .= "," . $size;
-        }
-
-        $expansion = qq{\\MathJaxImg[$opt]{$out_file}};
-    }
 
     return $tex->tokenize($expansion);
 }
@@ -829,18 +810,7 @@ sub do_texml_import_svg {
 
     my $expansion;
 
-    if ($tex->is_mmode()) {
-        my $doc = XML::LibXML->load_xml(location => $svg_path);
-
-        my $root = $doc->documentElement();
-
-        my $width  = $root->getAttribute("width");
-        my $height = $root->getAttribute("height");
-
-        $expansion = qq{\\MathJaxImg[width=$width,height=$height]{$svg_path}};
-    } else {
-        $expansion = qq{\\TeXMLImportGraphic{$svg_path}};
-    }
+    $expansion = qq{\\TeXMLImportGraphic{$svg_path}};
 
     return $tex->tokenize($expansion);
 }

--- a/tests/graphics.xml
+++ b/tests/graphics.xml
@@ -7,7 +7,7 @@
   <p>
     <disp-formula content-type="math/tex">
       <tex-math>\begin{equation*}
- F_{\ell , \ell ', \delta } \colon  \vcenter{\img[width=279pt,height=20pt]{Images/img787c28a5a51663ea92034cd97eb291ff.svg}}, 
+ F_{\ell , \ell ', \delta } \colon  <inline-graphic height="20pt" mimetype="image/svg+xml" width="279pt" xlink:href="Images/img787c28a5a51663ea92034cd97eb291ff.svg"/>, 
 \end{equation*}</tex-math>
     </disp-formula>
   </p>


### PR DESCRIPTION
Always create graphic elements, removing special treatment of
graphics inside math-mode (via the custom \img macro).