### PR TITLE
HTMLtable.pm: change the default border color to currentColor

### DIFF
--- a/lib/perl/TeX/Interpreter/LaTeX/Package/HTMLtable.pm
+++ b/lib/perl/TeX/Interpreter/LaTeX/Package/HTMLtable.pm
@@ -265,7 +265,7 @@ __DATA__
 
 \def\default@border@width{thin}
 \def\default@border@style{solid}
-\def\default@border@color{black}
+\def\default@border@color{currentColor}
 
 \def\reset@border@style{%
     \let\current@border@width\default@border@width


### PR DESCRIPTION
Switches the default border color from black to currentColor to improve downstream rendering in color modes.

Part of #153