### PR TITLE
return non-zero exit code if XML output fails to generate (issue #226),  note additional files can be process in -help output

### DIFF
--- a/bin/texml
+++ b/bin/texml
@@ -114,7 +114,7 @@ our %OPT = (debug        => 0,
 
 sub usage() {
     my $usage = << "EOF";
-Usage: $PROGRAM_NAME [options] filename
+Usage: $PROGRAM_NAME [options] filename [additional_filenames]
 
 Options:
     -help           Print this help text and quit.
@@ -281,6 +281,7 @@ sub process_file( $ ) {
 
         if ($@) {
             print "Could not pretty-print file: $@\n";
+	    die;
         }
     }
 
@@ -332,9 +333,9 @@ if ($OPT{debug}) {
 }
 
 while (my $tex_file = shift @ARGV) {
-    do { warn "Can't find $tex_file\n"; next; } unless -e $tex_file;
+    do { warn "Can't find $tex_file\n"; die; next; } unless -e $tex_file;
 
-    do { warn "Can't read $tex_file\n"; next; } unless -r $tex_file;
+    do { warn "Can't read $tex_file\n"; die; next; } unless -r $tex_file;
 
     process_file($tex_file);
 


### PR DESCRIPTION
add some "die" statements to texml so that if an XML output file
cannot be generated from any input file the script will exit with a non-zero return code, as is expected of unix-like programs that fail to run successfully.  (noted in [issue #226](https://github.com/AmerMathSoc/texml/issues/226))

Also: modify the usage note (what the -help option will cause to be printed) to document that the script will process all filenames based as agruments to the script