### PR TITLE
amsrefs arXiv fix

### DIFF
--- a/lib/perl/TeX/Interpreter/LaTeX/Package/amsrefs.pm
+++ b/lib/perl/TeX/Interpreter/LaTeX/Package/amsrefs.pm
@@ -533,11 +533,7 @@ __DATA__
 \def\parse@arXiv#1 [#2]#3\@nnil{%
     \def\arXiv@number{#1}%
     \def\arXiv@category{#2}%
-    \ifx\arXiv@category\@empty
-        \def\arXiv@url{https://arxiv.org/abs/#1}%
-    \else
-        \def\arXiv@url{https://arxiv.org/abs/\arXiv@category/#1}%
-    \fi
+    \def\arXiv@url{https://arxiv.org/abs/#1}%
 }
 
 \providecommand{\arXiv}[1]{%

--- a/tests/amsrefs.tex
+++ b/tests/amsrefs.tex
@@ -44,6 +44,10 @@ Eng 3: \cite{Enna3}
 
 Eng 4: \cite{Enna4}
 
+arXiv: \arXiv{1405.7064}
+
+arXiv w/ category: \arXiv{1405.7064 [math.NT]}
+
 \begin{bibsection}
 
 \begin{biblist}

--- a/tests/amsrefs.xml
+++ b/tests/amsrefs.xml
@@ -23,6 +23,8 @@
       <p>Eng 2: <cite-group><x>[</x><xref ref-type="bibr" rid="bibr-Enna2" specific-use="cite">Engb</xref><x>]</x></cite-group></p>
       <p>Eng 3: <cite-group><x>[</x><xref ref-type="bibr" rid="bibr-Enna3" specific-use="cite">Engc</xref><x>]</x></cite-group></p>
       <p>Eng 4: <cite-group><x>[</x><xref ref-type="bibr" rid="bibr-Enna4" specific-use="cite">Engd</xref><x>]</x></cite-group></p>
+      <p>arXiv: <ext-link xlink:href="https://arxiv.org/abs/1405.7064"><monospace>arXiv:1405.7064</monospace></ext-link></p>
+      <p>arXiv w/ category: <ext-link xlink:href="https://arxiv.org/abs/1405.7064"><monospace>arXiv:1405.7064 [math.NT]</monospace></ext-link></p>
     </sec>
   </body>
   <back id="ltxid4">

--- a/tests/amsrefs.xml.ref
+++ b/tests/amsrefs.xml.ref
@@ -23,6 +23,8 @@
       <p>Eng 2: <cite-group><x>[</x><xref ref-type="bibr" rid="bibr-Enna2" specific-use="cite">Engb</xref><x>]</x></cite-group></p>
       <p>Eng 3: <cite-group><x>[</x><xref ref-type="bibr" rid="bibr-Enna3" specific-use="cite">Engc</xref><x>]</x></cite-group></p>
       <p>Eng 4: <cite-group><x>[</x><xref ref-type="bibr" rid="bibr-Enna4" specific-use="cite">Engd</xref><x>]</x></cite-group></p>
+      <p>arXiv: <ext-link xlink:href="https://arxiv.org/abs/1405.7064"><monospace>arXiv:1405.7064</monospace></ext-link></p>
+      <p>arXiv w/ category: <ext-link xlink:href="https://arxiv.org/abs/1405.7064"><monospace>arXiv:1405.7064 [math.NT]</monospace></ext-link></p>
     </sec>
   </body>
   <back id="ltxid4">


### PR DESCRIPTION
This PR relates to issue #229. 

It seems like a change was introduced in commit 0d1294f978063080254f2e73ebd49 which broke arXiv URL creation. Perhaps there's a reason for the change that I'm overlooking; are there perhaps _some_ categories which need to preface the identifier?

I patched the `amsrefs` module to not include the category in the arXiv URL. I also updated the amsrefs test files to test for the output of a manual `\arXiv` command. 

Note that the definition of `\parse@arXiv` in the `arXiv` package module agrees with the definition here. However, I can't think of an instance where we have used the `arXiv` package over the functionality built into `amsrefs`. 