### PR TITLE
TeX::Interpreter::LaTeX::Class::notices: pullquote macro

### DIFF
--- a/lib/perl/TeX/Interpreter/LaTeX/Class/notices.pm
+++ b/lib/perl/TeX/Interpreter/LaTeX/Class/notices.pm
@@ -473,6 +473,15 @@ __DATA__
     \thisxmlpartag{title}#1\par
 }
 
+\newcommand{\pullquote}[3][0]{%
+    \par
+    \startXMLelement{disp-quote}%
+    \setXMLattribute{content-type}{pullquote}
+    #3
+    \par
+    \endXMLelement{disp-quote}%
+}
+
 \endinput
 
 __END__

--- a/tests/notices.tex
+++ b/tests/notices.tex
@@ -1,0 +1,19 @@
+%% AMS prddvilualatex
+
+\documentclass{notices}
+
+\csname noTeXMLhistory\endcsname
+
+\title{Notices}
+
+\loggingoutput
+
+\begin{document}
+
+\maketitle
+
+\section{Custom macros}
+
+\pullquote{10pc}{A simple pull quote}
+
+\end{document}

--- a/tests/notices.xml
+++ b/tests/notices.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//AMS TEXML//DTD MODIFIED JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.3d2 20201130//EN" "texml-jats-1-3d2.dtd">
+<article xmlns:xlink="http://www.w3.org/1999/xlink">
+  <front id="ltxid1">
+    <journal-meta>
+      <journal-id journal-id-type="publisher">noti</journal-id>
+      <journal-title-group>
+        <journal-title>Notices of the American Mathematical Society</journal-title>
+        <abbrev-journal-title>Notices Amer. Math. Soc.</abbrev-journal-title>
+      </journal-title-group>
+      <issn publication-format="print">0002-9920</issn>
+      <issn publication-format="electronic">1088-9477</issn>
+      <publisher>
+        <publisher-name>American Mathematical Society</publisher-name>
+        <publisher-loc>Providence, Rhode Island</publisher-loc>
+      </publisher>
+    </journal-meta>
+    <article-meta>
+      <title-group>
+        <article-title>Notices</article-title>
+      </title-group>
+    </article-meta>
+  </front>
+  <body id="ltxid2">
+    <sec id="ltxid3" specific-use="section">
+      <label>1<x>.</x></label>
+      <title>Custom macros</title>
+      <disp-quote content-type="pullquote">
+        <p>A simple pull quote</p>
+      </disp-quote>
+    </sec>
+  </body>
+</article>


### PR DESCRIPTION
- lib/perl/TeX/Interpreter/LaTeX/Class/notices.pm
  - add \pullquote macro
    - based on existing use case
    - maps to disp-quote  with content-type=pullquote
- test
  - add notices test file with pullquote